### PR TITLE
Issue 3 - MalformedJsonException after login

### DIFF
--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/JWT.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/JWT.java
@@ -35,7 +35,7 @@ public class JWT {
       LOG.warn(String.format("JWT is malformed since consist of %d parts instead of required 3.", jwtParts.length));
       return null;
     }
-    final String jwsPayload = jwtParts[1];
+    final String jwsPayload = addPadding(jwtParts[1]);
     final JsonElement jsonElement;
     try {
       final byte[] jwsPayloadBytes = jwsPayload.getBytes(UTF8);
@@ -51,6 +51,18 @@ public class JWT {
       return null;
     }
     return new JWT(jsonElement.getAsJsonObject());
+  }
+
+  private static String addPadding(String base64EncodedString) {
+    int numCharsToPad = base64EncodedString.length() % 4;
+    if (numCharsToPad  == 0) {
+      return base64EncodedString;
+    }
+      StringBuffer buf = new StringBuffer(base64EncodedString);
+      for(int i = 0; i < numCharsToPad; i++) {
+        buf.append('=');
+      }
+    return buf.toString();
   }
 
   @Nullable


### PR DESCRIPTION
I added padding indicators to the claims token of the base64 encoded JWT string if the length was not a multiple of 4. Added unit tests as well to demonstrate the problem and fix it, but I am not sure if you want such a "big change" (adding unit tests) in the same pull request.

I could reproduce the problem with an example JWT token found here: https://developer.atlassian.com/static/connect/docs/latest/concepts/understanding-jwt.html

eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEzODY4OTkxMzEsImlzcyI6ImppcmE6MTU0ODk1OTUiLCJxc2giOiI4MDYzZmY0Y2ExZTQxZGY3YmM5MGM4YWI2ZDBmNjIwN2Q0OTFjZjZkYWQ3YzY2ZWE3OTdiNDYxNGI3MTkyMmU5IiwiaWF0IjoxMzg2ODk4OTUxfQ.uKqU9dTB6gKwG6jQCuXYAiMNdfNRw98Hw_IWuA5MaMo

Without the fix, we get an exception. With the fix, the exception is gone.
